### PR TITLE
Added check if group should be expanded.

### DIFF
--- a/scripts/h5peditor-group.js
+++ b/scripts/h5peditor-group.js
@@ -118,6 +118,14 @@ ns.Group.prototype.appendTo = function ($wrapper) {
 
   // Set summary
   this.findSummary();
+  
+  //Check if group should be expanded. Default is to be expanded unless explicity defined in semantics by optional attribute expanded
+  if (this.field.expanded === false) {
+	  this.$group.removeClass('expanded');
+  }
+  else {
+	  this.$group.addClass('expanded');
+  }
 };
 
 /**


### PR DESCRIPTION
Check if group should be expanded. Default is to be expanded unless explicitly defined in semantics by optional attribute "expanded".
If the user does not want the group to be expanded he should add
 "expanded": false 
in the corresponding semantics file.
I have not tested it thoroughly but it seems to be working.