### PR TITLE
improve regexp for YouTube

### DIFF
--- a/scripts/h5peditor-av.js
+++ b/scripts/h5peditor-av.js
@@ -226,6 +226,10 @@ H5PEditor.widgets.video = H5PEditor.widgets.audio = H5PEditor.AV = (function ($)
       for (var i = 0; i < C.providers.length; i++) {
         if (C.providers[i].regexp.test(url)) {
           mime = C.providers[i].name;
+          // add protocol if missing
+          if (!url.startsWith('https://') && !url.startsWith('http://')) {
+            url = 'https://' + url;
+          }
           break;
         }
       }
@@ -324,7 +328,7 @@ H5PEditor.widgets.video = H5PEditor.widgets.audio = H5PEditor.AV = (function ($)
    */
   C.providers = [{
     name: 'YouTube',
-    regexp: /^https?:\/\/((youtu.|y2u.)?be|(www.|m.)?youtube.com)\//i
+    regexp: /(?:(?:youtube.com\/(?:attribution_link\?(?:\S+))?(?:v\/|embed\/|watch\/|(?:user\/(?:\S+)\/)?watch(?:\S+)v\=))|(?:youtu.be\/|y2u.be\/))([A-Za-z0-9_-]{11})/i
   }];
 
   return C;


### PR DESCRIPTION
Will (hopefully) provide full coverage of YouTube URLs, so the correct symbol is displayed. Please also consider pull request https://github.com/h5p/h5p-video/pull/11

resolves [HFP573](https://h5ptechnology.atlassian.net/browse/HFP-573) and [HFP-720](https://h5ptechnology.atlassian.net/browse/HFP-720)