### PR TITLE
Add custom event on h5peditor when it is ready to use

### DIFF
--- a/scripts/h5peditor-editor.js
+++ b/scripts/h5peditor-editor.js
@@ -14,8 +14,6 @@ var ns = H5PEditor;
  * @param {node} replace
  */
 ns.Editor = function (library, defaultParams, replace, iframeLoaded) {
-  'use strict';
-
   var self = this;
 
   // Library may return "0", make sure this doesn't return true in checks
@@ -39,10 +37,10 @@ ns.Editor = function (library, defaultParams, replace, iframeLoaded) {
       iframeLoaded.call(this.contentWindow);
     }
 
+    var editor = this;
     var LibrarySelector = this.contentWindow.H5PEditor.LibrarySelector;
     var $ = this.contentWindow.H5P.jQuery;
     var $container = $('body > .h5p-editor');
-    var parent = this.parentElement;
 
     this.contentWindow.H5P.$body = $(this.contentDocument.body);
 
@@ -67,7 +65,7 @@ ns.Editor = function (library, defaultParams, replace, iframeLoaded) {
           self.selector.setLibrary(library);
         }
 
-        parent.dispatchEvent(new CustomEvent('h5peditor-ready', { detail: self }));
+        H5P.externalDispatcher.trigger('editorLoaded', editor);
       }
     });
 

--- a/scripts/h5peditor-editor.js
+++ b/scripts/h5peditor-editor.js
@@ -14,6 +14,8 @@ var ns = H5PEditor;
  */
 ns.Editor = function (library, defaultParams, replace, iframeLoaded) {
   var self = this;
+  var parentWindow = window;
+
   // Library may return "0", make sure this doesn't return true in checks
   library = library && library != 0 ? library : '';
 
@@ -60,6 +62,8 @@ ns.Editor = function (library, defaultParams, replace, iframeLoaded) {
       if (library) {
         self.selector.setLibrary(library);
       }
+
+      parentWindow.dispatchEvent(new parentWindow.CustomEvent('h5peditor-ready', { detail: self }));
     });
 
     // Start resizing the iframe

--- a/scripts/h5peditor-selector-hub.js
+++ b/scripts/h5peditor-selector-hub.js
@@ -40,6 +40,7 @@ ns.SelectorHub = function (selectedLibrary, changeLibraryDialog) {
       .then(function (contentType) {
         if (!self.currentLibrary) {
           self.currentLibrary = self.createContentTypeId(contentType, true);
+          H5P.externalDispatcher.trigger('librarySelected', self.currentLibrary);
           self.trigger('selected');
           return;
         }
@@ -81,6 +82,7 @@ ns.SelectorHub = function (selectedLibrary, changeLibraryDialog) {
 
   // Clear upload field when changing library
   changeLibraryDialog.on('confirmed', function () {
+    H5P.externalDispatcher.trigger('librarySelected', self.currentLibrary);
     self.clearUploadForm();
   })
 };


### PR DESCRIPTION
This fix will add ability to listen when h5p editor is ready and use it api.
e.g. listen for library change etc.

you can listen this event outside of h5p editor: `window.addEventListener('h5peditor-ready', callback);`