### PR TITLE
Allowed uploading .svg files as images.

### DIFF
--- a/h5peditor-file.class.php
+++ b/h5peditor-file.class.php
@@ -131,9 +131,10 @@ class H5peditorFile {
           'image/png' => 'png',
           'image/jpeg' => array('jpg', 'jpeg'),
           'image/gif' => 'gif',
+          'image/svg+xml' => 'svg',
         );
         if (!$this->check($allowed)) {
-          $this->result->error = $this->interface->t('Invalid image file format. Use jpg, png or gif.');
+          $this->result->error = $this->interface->t('Invalid image file format. Use jpg, png, gif or svg.');
           return FALSE;
         }
 
@@ -146,6 +147,39 @@ class H5peditorFile {
           }
           else {
             $image = getimagesizefromstring($this->data);
+          }
+        }
+        elseif ($this->type === 'image/svg+xml') {
+
+          if (!function_exists('simplexml_load_file')) {
+            $this->result->error = $this->interface->t('Unable to process uploaded .svg image.');
+            return FALSE;
+          }
+
+          $svg = simplexml_load_file($_FILES['file']['tmp_name']);
+
+          if (isset($svg['width']) && isset($svg['height'])) {
+            $width = preg_replace('/[^0-9,.]/', '', $svg['width']);
+            $height = preg_replace('/[^0-9,.]/', '', $svg['height']);
+
+            if (!($width > 0 && $height > 0)) {
+              $this->result->error = $this->interface->t('Unable to determine size of uploaded .svg image.');
+              return FALSE;
+            }
+
+            $image = array($width, $height);
+          } else if (isset($svg['viewBox'])) {
+            $split = explode(' ', $svg['viewBox']);
+
+            if (!(is_array($split) && sizeof($split) === 4 && $split[2] > 0 && $split[3] > 0)) {
+              $this->result->error = $this->interface->t('Unable to determine size of uploaded .svg image.');
+              return FALSE;
+            }
+
+            $image = array($split[2], $split[3]);
+          } else {
+            $this->result->error = $this->interface->t('Unable to determine size of uploaded .svg image.');
+            return FALSE;
           }
         }
         else {

--- a/scripts/h5peditor-file-uploader.js
+++ b/scripts/h5peditor-file-uploader.js
@@ -253,7 +253,7 @@ H5PEditor.FileUploader = (function ($, EventDispatcher) {
         mimes = field.mimes.join(',');
       }
       else if (field.type === 'image') {
-        mimes = 'image/jpeg,image/png,image/gif';
+        mimes = 'image/jpeg,image/png,image/gif,image/svg+xml';
       }
       else if (field.type === 'audio') {
         mimes = 'audio/mpeg,audio/x-wav,audio/ogg';


### PR DESCRIPTION
This should be a working solution work with well formatted `svg` images (exported from graphical editors). It assumes the presence of `width` and `height` or `viewBox` attributes (grabbing values from the first available source).

In case of `width and height`, the code mostly assumes the use of pixels, though it just strips any symbols that do not seem to be a number (this could still lead to strange consequences with regard to size).

For the `viewBox` case, it does just assume only plain numbers being present.

Every value is checked to be greater than zero. If the size is not in pixels, it should still be mostly working, due to ratio being correct (although not the values themselves).

One additional requirement is the SimpleXML extension, used for reading the files and extracting the attributes (one could also add a way to extract those with multiple different libraries, depending on which one being present).

It should be noted, that `svgz` files are not supported. Those could have issues with in-browser editor or some other aspects of the system, it would also require unzipping the XML content of the file first.