### PR TITLE
Use appropriate separator for ajax url.

### DIFF
--- a/scripts/h5peditor-init.js
+++ b/scripts/h5peditor-init.js
@@ -61,9 +61,11 @@
     var url = H5PIntegration.editor.ajaxPath + action;
 
     if (parameters !== undefined) {
+	  var separator = url.indexOf('?') === -1 ? '?' : '&';
       for (var property in parameters) {
         if (parameters.hasOwnProperty(property)) {
-          url += '&' + property + '=' + parameters[property];
+          url += separator + property + '=' + parameters[property];
+		  separator = '&';
         }
       }
     }


### PR DESCRIPTION
Fixes an issue where the ajaxpath is never given a "?" to separate query parameters.