### PR TITLE
Let singleChild's default value be applied

### DIFF
--- a/scripts/h5peditor-group.js
+++ b/scripts/h5peditor-group.js
@@ -109,6 +109,7 @@ ns.Group.prototype.appendTo = function ($wrapper) {
     this.children = [];
     var field = this.field.fields[0];
     var widget = field.widget === undefined ? field.type : field.widget;
+    this.params = this.params === undefined ? this.field.fields[0].default : this.params;
     this.children[0] = new ns.widgets[widget](this, field, this.params, function (field, value) {
       that.setValue(that.field, value);
     });


### PR DESCRIPTION
If there's only one child in a group it's default value had not been applied since this.params is undefined. I solved it by just taking the default-value from field.