### PR TITLE
BUGFIX: Fix capitalization of the "Content-Type" HTTP header.

### DIFF
--- a/h5peditor-file.class.php
+++ b/h5peditor-file.class.php
@@ -265,7 +265,7 @@ class H5peditorFile {
 
     // text/plain is used to support IE
     header('Cache-Control: no-cache');
-    header('Content-type: text/plain; charset=utf-8');
+    header('Content-Type: text/plain; charset=utf-8');
 
     print $this->getResult();
   }


### PR DESCRIPTION
The "Content-Type" header is capitalized incorrectly. This can lead to unexpected behaviour when parsing responses (e.g. JSON being loaded as strings instead of objects by the JS engine). See https://tools.ietf.org/html/rfc7231#section-3.1.1.5.