### PR TITLE
Enable file upload in iOS Safari

### DIFF
--- a/scripts/h5peditor-file-uploader.js
+++ b/scripts/h5peditor-file-uploader.js
@@ -89,11 +89,14 @@ H5PEditor.FileUploader = (function ($, EventDispatcher) {
       const input = document.createElement('input');
       input.type = 'file';
       input.setAttribute('accept', determineAllowedMimeTypes());
+      input.style='display:none';
       input.addEventListener('change', function () {
         // When files are selected, upload them
         self.uploadFiles(this.files);
+        document.body.removeChild(input);
       });
 
+      document.body.appendChild(input);
       // Open file selector
       input.click();
     };


### PR DESCRIPTION
File upload does not work in iOS Safari. Change event is not triggered if element is not appended to DOM.
See https://stackoverflow.com/questions/47664777/javascript-file-input-onchange-not-working-ios-safari-only/47665517#47665517