### PR TITLE
* Replaced DIRECTORY_SEPARATOR

### DIFF
--- a/h5peditor.class.php
+++ b/h5peditor.class.php
@@ -741,7 +741,7 @@ class H5peditor {
    * @param string $prefix
    */
   public function addPresaveFile(&$assets, $library, $prefix = ''){
-    $path = 'libraries' . DIRECTORY_SEPARATOR . H5PCore::libraryToString($library, true);
+    $path = 'libraries' . '/' . H5PCore::libraryToString($library, true);
     if( array_key_exists('path', $library)){
       $path = $library['path'];
     }
@@ -751,7 +751,7 @@ class H5peditor {
     }
 
     $assets['scripts'][] = (object) array(
-      'path' => $prefix . DIRECTORY_SEPARATOR . $path . DIRECTORY_SEPARATOR . 'presave.js',
+      'path' => $prefix . '/' . $path . '/' . 'presave.js',
       'version' => $version,
     );
   }


### PR DESCRIPTION
DIRECTORY_SEPARATOR is not supposed to be used to compose paths; it is supposed to be used with rtrim and other operations on paths handed to you by the system.
All PHP running platforms support '/' as path separator.

Please see https://www.google.com/search?q=directory_separator+php+Windows