### PR TITLE
fix: prevent resize if iframe is not ready

### DIFF
--- a/scripts/h5peditor-editor.js
+++ b/scripts/h5peditor-editor.js
@@ -80,7 +80,7 @@ ns.Editor = function (library, defaultParams, replace, iframeLoaded) {
    * @private
    */
   var resize = function () {
-    if (!iframe.contentDocument.body || self.preventResize) {
+    if (!iframe.contentDocument || !iframe.contentDocument.body || self.preventResize) {
       return; // Prevent crashing when iframe is unloaded
     }
     if (iframe.clientHeight === iframe.contentDocument.body.scrollHeight &&


### PR DESCRIPTION
Hey,

I encountered an error when resizing before the iframe is not ready, but the editor tries to resize it.

```
TypeError: null is not an object (evaluating 'iframe.contentDocument.body')
  at resize (/api/v0/h5p/editor/scripts/h5peditor-editor.js:83:32)
  at None (/api/v0/h5p/editor/scripts/h5peditor-editor.js:190:19)
```

This should prevent this error from occurring.