### PR TITLE
Trigger on list item moved

### DIFF
--- a/scripts/h5peditor-list.js
+++ b/scripts/h5peditor-list.js
@@ -231,6 +231,7 @@ H5PEditor.List = (function ($) {
         var params = parameters.splice(currentIndex, 1);
         parameters.splice(newIndex, 0, params[0]);
       }
+      self.trigger('movedItem', {from: currentIndex, to: newIndex});
     };
 
     /**


### PR DESCRIPTION
When merged in, will allow widgets to not only listen to 'addedItem' and to 'removedItem', but also to 'movedItem'. Would allow widgets to detect changes in the order of the items.