### PR TITLE
Allow SVG files to be loaded and edited

### DIFF
--- a/h5peditor-file.class.php
+++ b/h5peditor-file.class.php
@@ -246,7 +246,7 @@ class H5peditorFile {
    * @param {int[]} [$fallbackSize=[300,150]] Fallback size.
    * @return {int[]} Width and height of image.
    */
-  private function getSVGimagesize($filename, $fallbackSize = [300, 150]) {
+  private function getSVGimagesize($filename, $fallbackSize = array(300, 150)) {
     if (!function_exists('simplexml_load_file')) {
       return $fallbackSize;
     }
@@ -262,7 +262,7 @@ class H5peditorFile {
 
     // Can use fixed dimensions
     if ($width && $height) {
-      return [$width, $height];
+      return array($width, $height);
     }
 
     if (!isset($xmlget->attributes()->viewBox)) {
@@ -279,12 +279,12 @@ class H5peditorFile {
 
     // Fixed width set, scale height accordingly
     if ($width) {
-      return [$width, $width / $viewBoxWidth * $viewBoxHeight];
+      return array($width, $width / $viewBoxWidth * $viewBoxHeight);
     }
 
     // Fixed height set, scale width accordingly
     if ($height) {
-      return [$height / $viewBoxHeight * $viewBoxWidth, $height];
+      return array($height / $viewBoxHeight * $viewBoxWidth, $height);
     }
 
     // Scale to fallback size using given ratio
@@ -292,10 +292,10 @@ class H5peditorFile {
     $ratioFallback = $fallbackSize[0] / $fallbackSize[1];
 
     if ($ratioImage - $ratioFallback > 0) {
-      return [$fallbackSize[0], $viewBoxHeight * $fallbackSize[0] / $viewBoxWidth];
+      return array($fallbackSize[0], $viewBoxHeight * $fallbackSize[0] / $viewBoxWidth);
     }
     else {
-      return [$viewBoxWidth * $fallbackSize[1] / $viewBoxHeight, $fallbackSize[1]];
+      return array($viewBoxWidth * $fallbackSize[1] / $viewBoxHeight, $fallbackSize[1]);
     }
   }
 
@@ -306,7 +306,7 @@ class H5peditorFile {
    */
   private function getPixelValue($size = 0) {
     // Cmp. https://www.w3.org/Style/Examples/007/units.en.html, assuming 96dpi
-    $map = [
+    $map = array(
       'px' => 1,
       'em' => 16, // common default font size display
       'ex' => 8, // uncommon value, best guess
@@ -315,7 +315,7 @@ class H5peditorFile {
       'in' => 96,
       'cm' => 96 / 2.54,
       'mm' => 96 / 25.4,
-    ];
+    );
 
     $size = trim($size);
 

--- a/scripts/h5peditor-file-uploader.js
+++ b/scripts/h5peditor-file-uploader.js
@@ -114,7 +114,7 @@ H5PEditor.FileUploader = (function ($, EventDispatcher) {
 
       switch (field.type) {
         case 'image':
-          return 'image/jpeg,image/png,image/gif';
+          return 'image/jpeg,image/png,image/gif,image/svg+xml';
         case 'audio':
           return 'audio/mpeg,audio/x-wav,audio/ogg,audio/mp4';
         case 'video':

--- a/scripts/h5peditor-image.js
+++ b/scripts/h5peditor-image.js
@@ -59,7 +59,7 @@ ns.widgets.image = function (parent, field, params, setValue) {
     // Uploaded new original image
     if (self.isOriginalImage) {
       delete self.params.originalImage;
-      self.editImagePopup.mime = self.params.mime
+      self.editImagePopup.mime = self.params.mime;
     }
 
     // Store width and height
@@ -123,6 +123,12 @@ ns.widgets.image.prototype.appendTo = function ($wrapper) {
 
     // Set current source as original image, if no original image
     if (!self.params.originalImage) {
+      // Need to convert SVG to PNG
+      if (self.params.mime === 'image/svg+xml') {
+        self.params.path = self.params.path.replace(/svg$/, 'png').replace(/svg#tmp$/, 'png#tmp');
+        self.params.mime = 'image/png';
+      }
+
       self.params.originalImage = {
         path: self.params.path,
         mime: self.params.mime,
@@ -245,6 +251,17 @@ ns.widgets.image.prototype.addFile = function () {
 
   var $img = this.$file.find('img');
   $img.one('load', function () {
+    // IE11 needs explicit dimensions for SVGs, can't use 'auto' value
+    if (that.params.mime === 'image/svg+xml') {
+      width = that.params.width;
+      height = that.params.height;
+
+      if (height > parseInt($img.css('maxHeight'))) {
+        width = width * parseInt($img.css('maxHeight')) / height;
+      }
+      $img.css('width', width + 'px');
+    }
+
     // Make editor resize
     $img.addClass('loaded');
   });


### PR DESCRIPTION
When merged in, SVG images can be loaded and edited on the server-side of H5P.

- Add SVG to list of allowed MIME types for file dialog
- Add SVG to list of supported MIME types
- Create a `getSVGimagesize` function as counterpart to PHP's `getimagesize` to detect SVG image size
  - Detect fixed height first, then best effort scaling based on viewBox ratio, then fallback size
  - Handle different size units for fixed SVG height values by mapping them to pixel values (assuming 96dpi)
- Take care of IE11 thumbnail display
- Take care of image editing

_Caveat 1:_ Editing SVG images doesn't work on IE11 (yet) for a couple of reasons:
- The darkroom library would require a patch to detect the width and height of an SVG image when loaded as IE11 doesn't (e.g. by briefly adding the image to DOM and using the offsetWidth/offsetHeight to set height/width).
- The fabric library would need to be patched, because IE11 throws a security alert due to a missing try-catch phrase, and even then the image would not load (without crashing). If really necessary, I'll try to make it work as well, but Microsoft is going to say their first goodbye to IE11 in four weeks anyway, followed by more goodbyes in March and August (https://techcommunity.microsoft.com/t5/microsoft-365-blog/microsoft-365-apps-say-farewell-to-internet-explorer-11-and/ba-p/1591666) Maybe it's time to say goodbye, too?

_Caveat 2:_ I assume that displaying SVG images correctly may need some extra CSS treatment in some content types at least for IE11, but I mentioned the goodbye phase already ...