### PR TITLE
Fix CKEditor basepath

### DIFF
--- a/scripts/h5peditor-html.js
+++ b/scripts/h5peditor-html.js
@@ -338,7 +338,7 @@ ns.Html.prototype.appendTo = function ($wrapper) {
     that.$placeholder = that.$item.find('.h5peditor-ckeditor-placeholder').detach();
 
     if (ns.Html.first) {
-      CKEDITOR.basePath = ns.basePath + '/ckeditor/';
+      CKEDITOR.basePath = ns.basePath + 'ckeditor/';
     }
 
     if (ns.Html.current === that) {


### PR DESCRIPTION
**Problem:** The CKEditor basepath is built with an extra slash resulting in something like `https://<H5P editor basepath>//ckeditor/`. It seems that most of the servers around the world ignore the two consecutive slashes, but at least one doesn't :-) There the CKEditor won't load instead.

**Fix:** Simply remove the prepended slash of the relative CKEditor path.

## Additional notes
No other path that's built using the `H5PEditor.basePath` property uses a prepended slash:
- https://github.com/h5p/h5p-editor-php-library/blob/master/scripts/h5peditor-html.js#L316
- https://github.com/h5p/h5p-editor-php-library/blob/master/scripts/h5peditor-image-popup.js#L158-L159
- https://github.com/h5p/h5p-editor-php-library/blob/master/scripts/h5peditor-metadata-changelog-widget.js#L265

So, if some platform used an H5PEditor basepath without a trailing slash, it would be in trouble anyway - but I checked nevertheless ...

All official H5P plugins/platforms populate the H5P editor basepath with a trailing slash:
- _Drupal 7_: https://git.drupalcode.org/project/h5p/-/blob/7.x-1.x-dev/modules/h5peditor/scripts/application.js#L19
- _Drupal 8_: https://git.drupalcode.org/project/h5p/-/blob/8.x-1.x-dev/modules/h5peditor/src/H5PEditor/H5PEditorUtilities.php#L49 via https://git.drupalcode.org/project/h5p/-/blob/8.x-1.x-dev/modules/h5peditor/scripts/application.js#L21
- _WordPress_: https://github.com/h5p/h5p-wordpress-plugin/blob/master/admin/class-h5p-content-admin.php#L1040 (see https://developer.wordpress.org/reference/functions/plugin_dir_url/ for trailing slash) via https://github.com/h5p/h5p-editor-php-library/blob/master/scripts/h5peditor-init.js#L4
- _moodle_: https://github.com/h5p/moodle-mod_hvp/blob/stable/locallib.php#L206 via https://github.com/h5p/h5p-editor-php-library/blob/master/scripts/h5peditor-init.js#L4
- _H5P.com_: Not sure where :-), but H5PIntegration.editor.libraryUrl ends with a slash

At least the inofficial versions that I checked also populate H5PIntegration.editor.libraryUrl accordingly:
- _node.js port_: https://github.com/Lumieducation/H5P-Nodejs-library/blob/master/src/UrlGenerator.ts#L22 via https://github.com/Lumieducation/H5P-Nodejs-library/blob/2f028acef720042c9599f56f77a6ef64c4775029/src/H5PEditor.ts#L891 via https://github.com/h5p/h5p-editor-php-library/blob/master/scripts/h5peditor-init.js#L4
- _moodle core_: Not tracked down, but H5PIntegration.editor.libraryUrl is set directly with a trailing slash