### PR TITLE
Fix PHP8.0 warning

### DIFF
--- a/h5peditor.class.php
+++ b/h5peditor.class.php
@@ -373,7 +373,7 @@ class H5peditor {
    *
    * @return array Libraries that was requested
    */
-  public function getLibraryData($machineName, $majorVersion, $minorVersion, $languageCode, $prefix = '', $fileDir = '', $defaultLanguage) {
+  public function getLibraryData($machineName, $majorVersion, $minorVersion, $languageCode, $prefix = '', $fileDir = '', $defaultLanguage = '') {
     $libraryData = new stdClass();
 
     $library = $this->h5p->loadLibrary($machineName, $majorVersion, $minorVersion);


### PR DESCRIPTION
As reported and fixed by  Marina Glancy in https://tracker.moodle.org/browse/MDL-70903, PHP 8.0 doesn't support required parameters after optional parameters.