### PR TITLE
Add support for "./" in findField path

### DIFF
--- a/scripts/h5peditor.js
+++ b/scripts/h5peditor.js
@@ -653,6 +653,10 @@ ns.findField = function (path, parent) {
     path = path.split('/');
   }
 
+  if (path[0] === '.') {
+    path.splice(0, 1);
+    return ns.findField(path, parent);
+  }
   if (path[0] === '..') {
     path.splice(0, 1);
     return ns.findField(path, parent.parent);


### PR DESCRIPTION
Currently, using `./` will not work. We must use `foo` instead of `./foo`.

This PR add this support. This might seems stupid to allow that as we just have to not write the `./` but:
- `./` is a valid path and is often used in html
- it usefull to allow a field to either be a value, or to point to an other field which will hold the value : we just have to detect if the value start with a `.` (this is something I use in a widget library I am developping and that I will use in two content type I am developping, I currently have to manually remove the `./` in the path to make it work).