### PR TITLE
JI-2981 Fix JS files being loaded multiple times

### DIFF
--- a/scripts/h5peditor.js
+++ b/scripts/h5peditor.js
@@ -56,34 +56,46 @@ ns.isIE = navigator.userAgent.match(/; MSIE \d+.\d+;/) !== null;
  */
 ns.renderableCommonFields = {};
 
-/**
- * Help load JavaScripts, prevents double loading.
- *
- * @param {string} src
- * @param {Function} done Callback
- */
-ns.loadJs = function (src, done) {
-  if (H5P.jsLoaded(src)) {
-    // Already loaded
-    done();
-  }
-  else {
-    // Loading using script tag
+(() => {
+  const loading = {}; // Map of callbacks for each src being loaded
+
+  /**
+   * Help load JavaScripts, prevents double loading.
+   *
+   * @param {string} src
+   * @param {Function} done Callback
+   */
+  ns.loadJs = (src, done) => {
+    if (H5P.jsLoaded(src)) {
+      // Already loaded
+      done(); 
+      return;
+    }
+
+    if (loading[src] !== undefined) {
+      // Loading in progress...
+      loading[src].push(done);
+      return;
+    }
+
+    loading[src] = [done];
+
+    // Load using script tag
     var script = document.createElement('script');
     script.type = 'text/javascript';
     script.charset = 'UTF-8';
     script.async = false;
     script.onload = function () {
       H5PIntegration.loadedJs.push(src);
-      done();
+      loading[src].forEach(cb => cb());
     };
     script.onerror = function (err) {
-      done(err);
+      loading[src].forEach(cb => cb(err));
     };
     script.src = src;
     document.head.appendChild(script);
-  }
-}
+  };
+})();
 
 /**
  * Helper function invoked when a library is requested. Will add CSS and eval JS


### PR DESCRIPTION
This is an issue with complex editors/content types where code might be executing while it's being overwritten.
For example, this can happen when IV and CP are used together in Column and can cause strange bugs.