### PR TITLE
JI-2981 Fix js loading tracker not being cleaned

### DIFF
--- a/scripts/h5peditor.js
+++ b/scripts/h5peditor.js
@@ -88,9 +88,11 @@ ns.renderableCommonFields = {};
     script.onload = function () {
       H5PIntegration.loadedJs.push(src);
       loading[src].forEach(cb => cb());
+      delete loading[src];
     };
     script.onerror = function (err) {
       loading[src].forEach(cb => cb(err));
+      delete loading[src];      
     };
     script.src = src;
     document.head.appendChild(script);


### PR DESCRIPTION
Switching from one content type to another in the editor currently may fail, cmp. discussion at https://github.com/h5p/h5p-editor-php-library/commit/9869eac9d50d079aabcb11552900b8c22ebaab2e.

When merged in, this will work again.