### PR TITLE
JI-3620 Refactor use of glorified loop

### DIFF
--- a/scripts/h5peditor-form.js
+++ b/scripts/h5peditor-form.js
@@ -351,9 +351,9 @@ ns.Form.prototype.setSubContentDefaultLanguage = function (params, lang) {
   const self = this;
 
   if (Array.isArray(params)) {
-    params = params.map(function (listItem) {
-      return self.setSubContentDefaultLanguage(listItem, lang);
-    });
+    for (let i; i < params.length; i++) { 
+      params[i] = self.setSubContentDefaultLanguage(params[i], lang);
+    }
   }
   else if (typeof params === 'object') {
     if (params.metadata) {


### PR DESCRIPTION
The editor widgets relies on references to the parameter objects, changing the parameter object without updating the references means that the editor widgets will continue updating objects that won't be saved.