### PR TITLE
HFP-4291 Fix accessing patch_version_in_folder_name

### DIFF
--- a/h5peditor.class.php
+++ b/h5peditor.class.php
@@ -622,6 +622,10 @@ class H5peditor {
       $is_local_only = TRUE;
       $icon_path = NULL;
 
+      $patch_version_in_folder_name = (isset($local_lib->patch_version_in_folder_name)) ?
+        $local_lib->patch_version_in_folder_name :
+        null;
+
       // Check if icon is available locally:
       if ($local_lib->has_icon) {
         // Create path to icon:
@@ -630,7 +634,7 @@ class H5peditor {
           'majorVersion' => $local_lib->major_version,
           'minorVersion' => $local_lib->minor_version,
           'patchVersion' => $local_lib->patch_version,
-          'patchVersionInFolderName' => $local_lib->patch_version_in_folder_name
+          'patchVersionInFolderName' => $patch_version_in_folder_name
         ]);
         $icon_path = $this->h5p->h5pF->getLibraryFileUrl($library_folder, 'icon.svg');
       }


### PR DESCRIPTION
Currently, `$local_lib->patch_version_in_folder_name` may not be set when merging local libraries into cached libraries. Fixed by checking first.