### PR TITLE
Guard against undefined data in translations where semantics has entries

### DIFF
--- a/scripts/h5peditor.js
+++ b/scripts/h5peditor.js
@@ -275,11 +275,13 @@ ns.updateCommonFieldsDefault = function (semantics, translation, parentIsCommon)
       semantics[i].default = translation[i].default;
     }
     if (semantics[i].fields !== undefined && semantics[i].fields.length &&
-        translation[i].fields !== undefined && translation[i].fields.length) {
+        translation[i] !== undefined && translation[i].fields !== undefined &&
+        translation[i].fields.length) {
       // Look into sub fields
       ns.updateCommonFieldsDefault(semantics[i].fields, translation[i].fields, isCommon);
     }
-    if (semantics[i].field !== undefined && translation[i].field !== undefined ) {
+    if (semantics[i].field !== undefined && translation[i] !== undefined &&
+        translation[i].field !== undefined ) {
       // Look into sub field
       ns.updateCommonFieldsDefault([semantics[i].field], [translation[i].field], isCommon);
     }


### PR DESCRIPTION
It was found that in version 1.24.2 of "Interactive Video" there are entries in the semantics.json file, where the corresponding entries in the translations are missing. This breaks hard in h5peditor.js, function updateCommonFieldsDefault, where the fields from the semantics entries are iterated and `field` member of the translations entry is accessed without checking, that is actually exists.