### PR TITLE
Avoid unexpected 'Missing translations for library ...' messages.

### DIFF
--- a/scripts/h5peditor-editor.js
+++ b/scripts/h5peditor-editor.js
@@ -599,7 +599,7 @@ ns.hideAllButOne = function (element, win) {
  *
  * @member {Object} H5PEditor.language
  */
-ns.language = {};
+ns.language = ns.language || {};
 
 /**
  * Translate text strings.


### PR DESCRIPTION
Get unexpected 'Missing translations for library ...' messages when entering editor.

This maybe due to the order I am pulling in / executing the Javascript but I cannot see any difference between my framework and the Wordpress / Drupal network traffic (although those frameworks appear to use an earlier version of h5p-editor-php-library).