### PR TITLE
Update h5peditor.js to include Papiamento language

### DIFF
--- a/scripts/h5peditor.js
+++ b/scripts/h5peditor.js
@@ -1818,6 +1818,8 @@ ns.supportedLanguages = {
   'or': 'Oriya',
   'os': 'Ossetian',
   'pa': 'Punjabi',
+  'pap-cw': 'Papiamento (Curaçao and Bonaire)',
+  'pap-aw': 'Papiamento (Aruba)',
   'pi': 'Pali',
   'pl': 'Polish (Polski)',
   'ps': 'Pashto (پښتو)',


### PR DESCRIPTION
Include  'pap-cw (Papiamento (Curaçao and Bonaire)) and 'pap-aw' (Papiamento (Aruba)