### PR TITLE
Add Echo360 EchoVideos as a provider

### DIFF
--- a/scripts/h5peditor-av.js
+++ b/scripts/h5peditor-av.js
@@ -683,7 +683,12 @@ H5PEditor.widgets.video = H5PEditor.widgets.audio = H5PEditor.AV = (function ($)
       name: 'Vimeo',
       regexp: /^.*(vimeo\.com\/)((channels\/[A-z]+\/)|(groups\/[A-z]+\/videos\/))?([0-9]+)/,
       aspectRatio: '16:9',
-    }
+    },
+    {
+        name: 'Echo360',
+        regexp: /^[^\/]+:\/\/(echo360[^\/]+)\/media\/([^\/]+)\/h5p.*$/i,
+        aspectRatio: '16:9',
+    },
   ];
 
   /**


### PR DESCRIPTION
At Echo360 (https://echo360.com/) we have been asked by our customers to allow videos captured in our EchoVideo platform to be able to be included in H5P content. We have added these features in our test environment and they will be released generally at the end of the year.

For this to work in the same way as other supported video platforms it will require changes to both this repository as well as the H5P Video library. Our changes are modelled after the other video platforms.