### PR TITLE
HFP-3851 Fix select field validation

### DIFF
--- a/scripts/h5peditor-select.js
+++ b/scripts/h5peditor-select.js
@@ -118,7 +118,7 @@ H5PEditor.widgets.select = H5PEditor.Select = (function (E) {
       $errors.remove();
     }
 
-    return value;
+    return value ?? value === undefined;
   };
 
   /**


### PR DESCRIPTION
When merged in, will fix the `validate` function of a `select` field to return `true` if the field is optional and nothing (`-`) is chosen.

Close to 10 years ago (!?) the select field’s `validate` function was amended to allow choosing `-` which is equivalent to not choosing anything. The new code works fine if the field is mandatory and nothing is chosen - the return value of `validate` is `false`. However, if the field is optional and nothing is chosen, currently the return value of `validate` is `undefined`.