### PR TITLE
Add field name to library select field classname

### DIFF
--- a/scripts/h5peditor-library.js
+++ b/scripts/h5peditor-library.js
@@ -99,7 +99,7 @@ ns.Library.prototype.updateCopyPasteButtons = function () {
  */
 ns.Library.prototype.appendTo = function ($wrapper) {
   var that = this;
-  var html = '<div class="field ' + this.field.type + '">';
+  var html = '<div class="field ' + this.field.type + ' field-name-' + this.field.name + '">';
   const id = ns.getNextFieldId(this.field);
 
   if (this.field.label !== 0 && this.field.label !== undefined) {


### PR DESCRIPTION
When merged in, the `classname` of a library select field's DOM element will also contain `field-name-${field.name}`in order to create the same behavior that other fields' DOM elements show.