### PR TITLE
HFP-3852 Fix number field validation

### DIFF
--- a/scripts/h5peditor-number.js
+++ b/scripts/h5peditor-number.js
@@ -109,7 +109,7 @@ ns.Number.prototype.validate = function () {
     if (that.field.optional === true) {
       // Field is optional and does not have a value, nothing more to validate
       this.$input.removeClass('error');
-      return;
+      return true;
     }
 
     // Field must have a value


### PR DESCRIPTION
When merged in, will fix the `validate` function of a `number` field to return `true` if the field is optional and nothing is set.

Currently, the `validate` function returns `undefined` if the field is optional and not value is set. One can work around this, of course, but it feels unintuitive if the return value is a boolean for when the value does not validate but `undefined` if it validates.