### PR TITLE
HFP-3870 Prevent crash if H5P Integration does not provide file icon

### DIFF
--- a/scripts/h5peditor-init.js
+++ b/scripts/h5peditor-init.js
@@ -2,7 +2,11 @@
   H5PEditor.init = function ($form, $type, $upload, $create, $editor, $library, $params, $maxScore, $title, cancelSubmitCallback) {
     H5PEditor.$ = H5P.jQuery;
     H5PEditor.basePath = H5PIntegration.editor.libraryUrl;
-    H5PEditor.fileIcon = H5PIntegration.editor.fileIcon;
+    H5PEditor.fileIcon = H5PIntegration.editor.fileIcon ?? {
+      path: `${H5PEditor.basePath}/images/binary-file.png`,
+      width: 50,
+      height:50
+    };
     H5PEditor.ajaxPath = H5PIntegration.editor.ajaxPath;
     H5PEditor.filesPath = H5PIntegration.editor.filesPath;
     H5PEditor.apiVersion = H5PIntegration.editor.apiVersion;


### PR DESCRIPTION
When merged in, will prevent the editor from crashing if a "binary" file (e.g. VTT file) is uploaded and the H5P integration does not set H5PIntegration.editor.fileIcon properly (as the H5P CLI server currently).