### PR TITLE
HFP-3875 Fix detection of collapse capabilities

### DIFF
--- a/scripts/h5peditor-list-editor.js
+++ b/scripts/h5peditor-list-editor.js
@@ -162,10 +162,10 @@ H5PEditor.ListEditor = (function ($) {
      */
     self.hasCollapseCapabilities = () => {
       return (
-        this.container?.parentNode.querySelector(
+        this.container?.parentNode.firstChild.querySelector(
           '.h5p-editor-flex-wrapper .h5peditor-button-collapse'
         ) instanceof HTMLElement ||
-        this.container?.parentNode.querySelector(
+        this.container?.parentNode.firstChild.querySelector(
           '.h5peditor-label-button'
         ) instanceof HTMLElement
       );


### PR DESCRIPTION
When merged in, will fix detection of collapse capabilities when there is a list of groups inside a list of groups.

Currently, when all elements of a list of groups are removed and a new one is added, the main list will not receive collapse functionality again (as it detects the collapse capability of a list of groups further down in the hierarchy).