### PR TITLE
Fix programmatically removing a list item

### DIFF
--- a/scripts/h5peditor-list-editor.js
+++ b/scripts/h5peditor-list-editor.js
@@ -704,14 +704,17 @@ H5PEditor.ListEditor = (function ($) {
         'remove', H5PEditor.t('core', 'removeItem'), function () {
           confirmHandler(item, $item.index(), $(this).offset(), function () {
             list.removeItem($item.index());
-            $item.remove();
-
-            if (!(list.getValue() ?? []).length) {
-              self.removeCollapseButtons();
-            }
           });
         }
       ).appendTo($listActions);
+
+      list.on('removedItem', (event) => {
+        $item.remove();
+
+        if (!(list.getValue() ?? []).length) {
+          self.removeCollapseButtons();
+        }
+      });
 
       // Append new field item to content wrapper
       if (item instanceof H5PEditor.Group) {


### PR DESCRIPTION
When merged in, will remove the list editor's item element ($item) not only when removing the item via the GUI, but when programmatically removing the underlying list item.

Currently, the list editor item gets removed properly when using the GUI and when clicking on the remove button. If one calls `removeItem` on the underlying `list` instance, however, the list editor's item element ($item) is not removed.