### PR TITLE
Use removeItem for removeAllItems (list)

### DIFF
--- a/scripts/h5peditor-list.js
+++ b/scripts/h5peditor-list.js
@@ -238,15 +238,9 @@ H5PEditor.List = (function ($) {
         return;
       }
 
-      // Remove child fields
-      for (var i = 0; i < children.length; i++) {
-        children[i].remove();
+      while (children.length) {
+        self.removeItem(0);
       }
-      children = [];
-
-      // Clean up parameters
-      parameters = undefined;
-      setValue(field);
     };
 
     /**


### PR DESCRIPTION
When merged in, lists will use their `removeItem` function inside `removeAllItems`. Keeps the code DRY and also triggers `removedItem` events that other components may need.