### PR TITLE
Fix using default value for library widget

### DIFF
--- a/scripts/h5peditor-library.js
+++ b/scripts/h5peditor-library.js
@@ -322,6 +322,17 @@ ns.Library.prototype.librariesLoaded = function (libList) {
     self.runChangeCallback = false;
   }
   // Load default library.
+  if (typeof this.params === 'string') {
+    this.params = {
+      library: this.params,
+      metadata: {},
+      params: {},
+      subContentId: H5P.createUUID()
+    };
+
+    self.$select.val(this.params.library);
+  }
+  
   if (this.params.library !== undefined) {
     self.loadLibrary(this.params.library, true);
   }


### PR DESCRIPTION
When merged in, will fix using a `default` value set in semantics.

According to https://h5p.org/semantics#attribute-default the library widget should be able to accept a `default` value. That doesn't work currently, however.