### PR TITLE
[FIX] PHP 8.2 dynamic property

### DIFF
--- a/h5peditor.class.php
+++ b/h5peditor.class.php
@@ -50,7 +50,7 @@ class H5peditor {
     'scripts/h5peditor-pre-save.js',
     'ckeditor/ckeditor.js',
   );
-  private $h5p, $storage;
+  private $h5p, $storage, $content;
   public $ajax, $ajaxInterface, $content;
 
   /**


### PR DESCRIPTION
Hi folks,

I have stumbled upon an issue inside the `H5PEditor` class, where the `$content` property has been initialised dynamically inside [`H5PEditor::processParameters()`](https://github.com/h5p/h5p-editor-php-library/blob/8cd9c7fb9a3668fa553b0e093078e87a1fbcdc6d/h5peditor.class.php#L158) until now. Since PHP 8.2 this throws a deprecation notice, so I have added the declaration of this property to the other privates.

Kind regards
@thibsy