### PR TITLE
HFP-4083 Fix overengineering

### DIFF
--- a/scripts/h5peditor-group.js
+++ b/scripts/h5peditor-group.js
@@ -136,10 +136,6 @@ ns.Group.prototype.appendTo = function ($wrapper) {
   if (this.field.expanded === true) {
     this.expand();
   }
-  else {
-    // Implicitly be default, but others may want to know via event
-    this.collapse();
-  }
 };
 
 /**


### PR DESCRIPTION
When merged in, will not explicitly call collapse() on being attached.