### PR TITLE
HFP-4174 Allow Panopto videos from self-hosted Panopto instances

### DIFF
--- a/scripts/h5peditor-av.js
+++ b/scripts/h5peditor-av.js
@@ -1134,7 +1134,7 @@ H5PEditor.widgets.video = H5PEditor.widgets.audio = H5PEditor.AV = (function ($)
     },
     {
       name: 'Panopto',
-      regexp: /^[^\/]+:\/\/([^\/]*panopto\.[^\/]+)\/Panopto\/.+\?id=(.+)$/i,
+      regexp: /^[^\/]+:\/\/([^\/]+)\/Panopto\/.+\?id=(.+)$/i,
       aspectRatio: '16:9',
     },
     {


### PR DESCRIPTION
When merged in, will allow authors to use Panopto videos from self-hosted Panopto instances.

Is accompanied by https://github.com/h5p/h5p-video/pull/148