### PR TITLE
Fix for scenarios where content is inside the table-overflow-protection

### DIFF
--- a/scripts/h5peditor-html.js
+++ b/scripts/h5peditor-html.js
@@ -485,8 +485,15 @@ ns.Html.prototype.appendTo = function ($wrapper) {
         // Remove overflow protection on startup
         let initialData = editor.getData();
         if (initialData.includes('table-overflow-protection')) {
-          initialData = initialData.replace(/<div class=\"table-overflow-protection\">.*<\/div>/, '');
-          editor.setData(initialData);
+          const match = initialData.match(/<div class="table-overflow-protection">(.*?)<\/div>/);
+          if (match && match[0]) {
+            // Set the editor data to just the content of the table-overflow-protection div
+            editor.setData(match[0]);
+          } else {
+            // If no match is found, remove the external div
+            initialData = initialData.replace(/<div class="table-overflow-protection">.*?<\/div>/, '');
+            editor.setData(initialData);
+          }
         }
 
         // Mimic old enter_mode behaviour if not specifically set to 'p'


### PR DESCRIPTION
In some cases the editor saves data inside the table-overflow-protection div. When this happens, clicking the editor would remove all existing content.

This fixes those scenarios by extracting the inner content before removing the table-overflow-protection div.

The previous behaviour is kept when the content was already outside of the table-overflow-protection div