### PR TITLE
Allow for accordion panels to open with enter key

### DIFF
--- a/scripts/h5peditor-form.js
+++ b/scripts/h5peditor-form.js
@@ -55,7 +55,7 @@ ns.Form = function (library, startLanguages, defaultLanguage) {
         toggleCommonFields();
       },
       keypress: function (event) {
-        if ((event.charCode || event.keyCode) === 32) {
+        if ((event.charCode || event.keyCode) === 32 || (event.charCode || event.keyCode) === 13) { // Space or Enter
           toggleCommonFields();
           event.preventDefault();
         }

--- a/scripts/h5peditor-group.js
+++ b/scripts/h5peditor-group.js
@@ -92,7 +92,7 @@ ns.Group.prototype.appendTo = function ($wrapper) {
         that.toggle();
       },
       keypress: function (event) {
-        if ((event.charCode || event.keyCode) === 32) {
+        if ((event.charCode || event.keyCode) === 32 || (event.charCode || event.keyCode) === 13) { // Space or Enter
           that.toggle();
           event.preventDefault();
         }


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/MAV-3870

This PR fixes an issue where accordion panels in the editor would only expand/collapse with the spacebar when navigating the editor without a screenreader. Now accordion panels can expand/collapse with both the enter key and spacebar on either focus mode or browse mode.