### PR TITLE
Cancel button for metadata modal

### DIFF
--- a/scripts/h5peditor-form.js
+++ b/scripts/h5peditor-form.js
@@ -55,7 +55,7 @@ ns.Form = function (library, startLanguages, defaultLanguage) {
         toggleCommonFields();
       },
       keypress: function (event) {
-        if ((event.charCode || event.keyCode) === 32) {
+        if ((event.charCode || event.keyCode) === 32 || (event.charCode || event.keyCode) === 13) { // Space or Enter
           toggleCommonFields();
           event.preventDefault();
         }

--- a/scripts/h5peditor-group.js
+++ b/scripts/h5peditor-group.js
@@ -92,7 +92,7 @@ ns.Group.prototype.appendTo = function ($wrapper) {
         that.toggle();
       },
       keypress: function (event) {
-        if ((event.charCode || event.keyCode) === 32) {
+        if ((event.charCode || event.keyCode) === 32 || (event.charCode || event.keyCode) === 13) { // Space or Enter
           that.toggle();
           event.preventDefault();
         }

--- a/scripts/h5peditor-metadata-author-widget.js
+++ b/scripts/h5peditor-metadata-author-widget.js
@@ -154,6 +154,7 @@ H5PEditor.metadataAuthorWidget = function (semantics, params, $wrapper, parent) 
 
   return {
     addAuthor: addAuthor,
-    addDefaultAuthor: addDefaultAuthor
+    addDefaultAuthor: addDefaultAuthor,
+    renderAuthorList: renderAuthorList
   };
 };

--- a/scripts/h5peditor-metadata-changelog-widget.js
+++ b/scripts/h5peditor-metadata-changelog-widget.js
@@ -271,4 +271,8 @@ H5PEditor.metadataChangelogWidget = function (semantics, params, $wrapper, paren
       async: true
     });
   }
+
+  return {
+    render: render
+  };
 };


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/MAV-4010

This PR adds a cancel button on the metdata modal that resets the inputs and the params object to their state when the modal was opened, effectively undoing any unsaved changes. The PR also adds a confirmation dialog that appears when the cancel button is click and there are unsaved changes.