### PR TITLE
feat: add Bunny Stream and Gumlet video providers

### DIFF
--- a/scripts/h5peditor-av.js
+++ b/scripts/h5peditor-av.js
@@ -689,6 +689,16 @@ H5PEditor.widgets.video = H5PEditor.widgets.audio = H5PEditor.AV = (function ($)
         regexp: /^[^\/]+:\/\/(echo360[^\/]+)\/media\/([^\/]+)\/h5p.*$/i,
         aspectRatio: '16:9',
     },
+    {
+      name: 'Bunny',
+      regexp: /(?:iframe\.mediadelivery\.net\/embed)\/(\d+)\/([a-f0-9-]+)/i,
+      aspectRatio: '16:9',
+    },
+    {
+      name: 'Gumlet',
+      regexp: /(?:play\.gumlet\.io\/embed|gumlet\.com\/watch)\/([a-f0-9]+)/i,
+      aspectRatio: '16:9',
+    },
   ];
 
   /**


### PR DESCRIPTION
## Summary

Adds Bunny Stream and Gumlet to the `C.providers` array in the AV widget so the editor properly recognizes their URLs as known video providers.

### What this enables
- **Single-source mode** when a Bunny/Gumlet URL is entered (consistent with YouTube, Vimeo, Panopto, Echo360)
- **Correct MIME type** assignment (`video/Bunny`, `video/Gumlet`) instead of `video/unknown`
- **16:9 aspect ratio** metadata for proper editor preview sizing

### URL Patterns
| Provider | Pattern |
|----------|---------|
| Bunny Stream | `iframe.mediadelivery.net/embed/{libraryId}/{videoId}` |
| Gumlet | `play.gumlet.io/embed/{assetId}` |
| Gumlet | `gumlet.com/watch/{assetId}` |

### Companion PR
This is the companion change to [h5p/h5p-video#162](https://github.com/h5p/h5p-video/pull/162), which adds the corresponding video handlers (`bunny.js` and `gumlet.js`) to H5P.Video.