### PR TITLE
H5P-4357 Fix latent list item removal bug

### DIFF
--- a/scripts/h5peditor-list-editor.js
+++ b/scripts/h5peditor-list-editor.js
@@ -18,6 +18,14 @@ H5PEditor.ListEditor = (function ($) {
       'class': 'h5p-ul'
     });
 
+    list.on('removedItem', (event) => {
+      $list.children().eq(event.data).remove();
+
+      if (!(list.getValue() ?? []).length) {
+        self.removeCollapseButtons();
+      }
+    });
+
     /**
      * Add group collapse functionality to list editor if items are groups.
      */
@@ -707,18 +715,6 @@ H5PEditor.ListEditor = (function ($) {
           });
         }
       ).appendTo($listActions);
-
-      list.on('removedItem', (event) => {
-        if (event.data !== $item.index()) {
-          return;
-        }
-        
-        $item.remove();
-
-        if (!(list.getValue() ?? []).length) {
-          self.removeCollapseButtons();
-        }
-      });
 
       // Append new field item to content wrapper
       if (item instanceof H5PEditor.Group) {


### PR DESCRIPTION
When merged in, will fix a latent bug when items are removed and improve performance. Encountered that while working on a content type.

Currently, each list item has its own `removedItem` listener. When invoked, it will compare the removal index with the jQuery item's index in the list and skip removal if the indexes don't match.

That works if the events get received first and then the item is removed. Otherwise, the remaining item's indexes will have been updated and the guard not skip removal.

# Example: Two items a with index 0 and b with index 1.
1) `list` fires event `removedItem` for item 0.
2) item a in `list-editor` receives the event. Indexes match, so the item will be removed. 
3) Assuming that 2 is completed in the same animation frame. Then the index of item b will now be 0.
4) Only now item b in `list-editor` receives the event. Indexes match, so the item will be removed as well which is not what should happen.

# Fix
Fixed by installing only one `removedItem` listener that does not compare against $item.index(), but against the item's position in the DOM list (which here is the same) and only the correct target item will be removed. As a bonus, there now will only be one event listener per list, not one per list item, saving some resources.