### PR TITLE
HFP-3989 Toggle add/remove list item buttons as needed

### DIFF
--- a/scripts/h5peditor-list-editor.js
+++ b/scripts/h5peditor-list-editor.js
@@ -18,6 +18,18 @@ H5PEditor.ListEditor = (function ($) {
       'class': 'h5p-ul'
     });
 
+    list.on('listIsAtMinimum', (event) => {
+      // Button DOM may not have been added
+      window.requestAnimationFrame(() => {
+        const $removeButtons = $list.find('.h5p-li .list-item-title-bar .h5peditor-button.remove');
+        $removeButtons.toggle(!event.data);
+      });
+    });
+
+    list.on('listIsAtMaximum', (event) => {
+      $button.toggle(!event.data);
+    });
+
     /**
      * Add group collapse functionality to list editor if items are groups.
      */
@@ -712,7 +724,7 @@ H5PEditor.ListEditor = (function ($) {
         if (event.data !== $item.index()) {
           return;
         }
-        
+
         $item.remove();
 
         if (!(list.getValue() ?? []).length) {


### PR DESCRIPTION
When merged in, will

- show/hide the `add-entity` button based on the underlying list's maximum entity value,
- show/hide the `remove-entity` buttons based on the underlying list's minimum entity value.

Requires https://github.com/h5p/h5p-editor-php-library/pull/164 to work but will not crash without