### PR TITLE
Remove '-' option if libraries can be selected.

### DIFF
--- a/scripts/h5peditor-selector-legacy.js
+++ b/scripts/h5peditor-selector-legacy.js
@@ -11,7 +11,7 @@ ns.SelectorLegacy = function (libraries, selectedLibrary, changeLibraryDialog) {
   var defaultLibraryParameterized = selectedLibrary ? selectedLibrary.replace('.', '-').toLowerCase() : undefined;
   this.currentLibrary = selectedLibrary;
 
-  var options = '<option value="-">-</option>';
+  var options = libraries.length ? '' : '<option value="-">-</option>';
   for (var i = 0; i < libraries.length; i++) {
     var library = libraries[i];
     var libraryName = ns.libraryToString(library);


### PR DESCRIPTION
fixes https://github.com/h5p/h5p-wordpress-plugin/issues/160

Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
If the H5P Hub is not enabled, the legacy selector kicks in. It holds `-` (no content type) as the default selection. When that selection is chosen and confirmed, actually choosing a content type afterwards leads to a visual issue, see https://github.com/h5p/h5p-wordpress-plugin/issues/160 where there's not enough height to display the confirmation dialog.

**What is the new behaviour?**
Instead of trying to fix the visual issue, there will now simply not be a `-` option if libraries can be chosen. There's no point in selecting no content type.
In order to not break the `<select>` field if for whatever reason no libraries are provided, the `-` is still available as the only option.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
