### PR TITLE
fix / Fix editor overlaps moodle 5.2 sticky footer

### DIFF
--- a/scripts/h5peditor-editor.js
+++ b/scripts/h5peditor-editor.js
@@ -31,7 +31,6 @@ ns.Editor = function (library, defaultParams, replace, iframeLoaded) {
       width: '100%',
       height: '3em',
       border: 'none',
-      zIndex: 101,
       top: 0,
       left: 0
     },


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
Editor overlaps moodle 5.2 sticky footer with submit buttons.

**What is the new behaviour?**
I removed the unnecessary z-index that is generated via jQuery as the iframe's `element.style`. Now the editor no longer overlaps the footer.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [off] I linked related issues/discussions
- [x] I tested my changes locally
