### PR TITLE
fix: avoid misleading oversized-file upload errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A general library that is supposed to be used in most PHP implementations of H5P.",
   "scripts": {
+    "test": "node --test test/file-uploader.test.cjs",
     "build": "webpack && rm styles/css/index.js",
     "watch": "webpack --watch"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A general library that is supposed to be used in most PHP implementations of H5P.",
   "scripts": {
-    "test": "node --test test/file-uploader.test.cjs",
+    "test": "node --test",
     "build": "webpack && rm styles/css/index.js",
     "watch": "webpack --watch"
   },

--- a/scripts/h5peditor-file-uploader.js
+++ b/scripts/h5peditor-file-uploader.js
@@ -1,5 +1,7 @@
 H5PEditor.FileUploader = (function ($, EventDispatcher) {
 
+  const HTTP_STATUS_CONTENT_TOO_LARGE = 413;
+
   /**
    * File Upload API for H5P
    *
@@ -45,7 +47,7 @@ H5PEditor.FileUploader = (function ($, EventDispatcher) {
         catch (err) {
           H5P.error(err);
           // A non-JSON response does not necessarily mean that the file is too large.
-          uploadComplete.error = H5PEditor.t('core', request.status === 413 ? 'fileToLarge' : 'unknownFileUploadError');
+          uploadComplete.error = H5PEditor.t('core', request.status === HTTP_STATUS_CONTENT_TOO_LARGE ? 'fileToLarge' : 'unknownFileUploadError');
         }
 
         if (result !== undefined) {

--- a/scripts/h5peditor-file-uploader.js
+++ b/scripts/h5peditor-file-uploader.js
@@ -44,8 +44,8 @@ H5PEditor.FileUploader = (function ($, EventDispatcher) {
         }
         catch (err) {
           H5P.error(err);
-          // Add error data to event object
-          uploadComplete.error = H5PEditor.t('core', 'fileToLarge');
+          // A non-JSON response does not necessarily mean that the file is too large.
+          uploadComplete.error = H5PEditor.t('core', request.status === 413 ? 'fileToLarge' : 'unknownFileUploadError');
         }
 
         if (result !== undefined) {

--- a/test/file-uploader.test.cjs
+++ b/test/file-uploader.test.cjs
@@ -1,0 +1,77 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, '../scripts/h5peditor-file-uploader.js'), 'utf8');
+
+function uploadResponse(status, responseText) {
+  const events = [];
+  const errors = [];
+  let request;
+  const context = {
+    H5P: {
+      jQuery: {},
+      EventDispatcher: function () {
+        this.trigger = (name, data) => events.push({ name, data });
+      },
+      error: error => errors.push(error)
+    },
+    H5PEditor: {
+      t: (namespace, key) => key,
+      getAjaxUrl: () => '/files'
+    },
+    FormData: class {
+      append() {}
+    },
+    XMLHttpRequest: class {
+      constructor() {
+        this.upload = {};
+        this.status = status;
+        this.responseText = responseText;
+        request = this;
+      }
+      open() {}
+      send() {}
+    }
+  };
+  vm.runInNewContext(source, context);
+  const uploader = new context.H5PEditor.FileUploader({ type: 'image' });
+  uploader.upload({}, 'image.png');
+  request.onload();
+  const completed = events.filter(event => event.name === 'uploadComplete');
+  assert.equal(completed.length, 1);
+  return { result: completed[0].data, errors };
+}
+
+for (const status of [200, 401, 403, 500]) {
+  test(`uses a generic error for a non-JSON HTTP ${status} response`, () => {
+    const { result, errors } = uploadResponse(status, '<html>Unexpected response</html>');
+    assert.equal(result.error, 'unknownFileUploadError');
+    assert.equal(result.data, null);
+    assert.equal(errors.length, 1);
+  });
+}
+
+test('reports an oversized file for a non-JSON HTTP 413 response', () => {
+  const { result } = uploadResponse(413, '<html>Content Too Large</html>');
+  assert.equal(result.error, 'fileToLarge');
+  assert.equal(result.data, null);
+});
+
+test('preserves a server-provided validation message', () => {
+  const { result, errors } = uploadResponse(400, JSON.stringify({
+    success: false, message: 'File type is not allowed'
+  }));
+  assert.equal(result.error, 'File type is not allowed');
+  assert.equal(result.data, null);
+  assert.equal(errors.length, 0);
+});
+
+test('preserves a successful upload response', () => {
+  const { result, errors } = uploadResponse(200, JSON.stringify({ path: 'images/image.png' }));
+  assert.equal(result.error, null);
+  assert.equal(result.data.path, 'images/image.png');
+  assert.equal(errors.length, 0);
+});


### PR DESCRIPTION
Fixes #335.

When an upload returns a non-JSON response, use the existing translated `unknownFileUploadError` message. Retain the `fileToLarge` message when the HTTP status is 413. This avoids sending users to investigate size limits when the response is actually an HTML login page, authorization failure, server error, or other malformed response.

Valid JSON responses keep their existing handling, including server-provided validation messages and successful upload data. No new translation strings or browser runtime dependencies are introduced.

Added a dependency-free Node test runner (`npm test`) that evaluates the actual uploader script with mocked browser APIs. Four cases fail before the fix and pass afterward; all seven tests cover non-JSON 200/401/403/500 responses, HTTP 413, a server validation message, and a successful upload. JavaScript syntax and git whitespace checks also pass.

Validated with Node 24. No PHP host integration or browser UI test was run; this change is limited to the JavaScript parse-error fallback. Prepared with AI assistance and tested locally.
