### PR TITLE
fix: support following text field changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A general library that is supposed to be used in most PHP implementations of H5P.",
   "scripts": {
+    "test": "node --test",
     "build": "webpack && rm styles/css/index.js",
     "watch": "webpack --watch"
   },

--- a/scripts/h5peditor-text.js
+++ b/scripts/h5peditor-text.js
@@ -11,8 +11,11 @@
 ns.Text = function (parent, field, params, setValue) {
   this.field = field;
   this.value = params;
+  this.params = params;
   this.setValue = setValue;
-  this.changeCallbacks = [];
+  this.changes = [];
+  // Deprecated alias kept for existing widgets using the text-specific API.
+  this.changeCallbacks = this.changes;
 };
 
 /**
@@ -37,15 +40,17 @@ ns.Text.prototype.appendTo = function ($wrapper) {
       if (H5P.trim(value) === '') {
         // Avoid storing empty strings. (will be valid if field is optional)
         delete that.value;
+        delete that.params;
         that.setValue(that.field);
       }
       else {
         that.value = value;
-        that.setValue(that.field, ns.htmlspecialchars(value));
+        that.params = ns.htmlspecialchars(value);
+        that.setValue(that.field, that.params);
       }
 
-      for (var i = 0; i < that.changeCallbacks.length; i++) {
-        that.changeCallbacks[i](value);
+      for (var i = 0; i < that.changes.length; i++) {
+        that.changes[i](value);
       }
     }
   });
@@ -55,13 +60,13 @@ ns.Text.prototype.appendTo = function ($wrapper) {
  * Run callback when value changes.
  *
  * @param {function} callback
- * @returns {Number|@pro;length@this.changeCallbacks}
+ * @returns {Number|@pro;length@this.changes}
  */
 ns.Text.prototype.change = function (callback) {
-  this.changeCallbacks.push(callback);
+  this.changes.push(callback);
   callback();
 
-  return this.changeCallbacks.length - 1;
+  return this.changes.length - 1;
 };
 
 /**

--- a/test/text-followers.test.cjs
+++ b/test/text-followers.test.cjs
@@ -1,0 +1,97 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function createText(initial = 'Initial', options = {}) {
+  let change;
+  let value = initial;
+  let error = '';
+  const saved = [];
+  const input = {
+    change(callback) {
+      if (callback) change = callback;
+      else change();
+      return this;
+    },
+    val(next) {
+      if (arguments.length) { value = next; return this; }
+      return value;
+    },
+    toggleClass() {}
+  };
+  const errors = {
+    html(next) { error = next; },
+    append(next) { error += next; }
+  };
+  const item = {
+    appendTo() { return this; },
+    find() { return input; },
+    children() { return errors; }
+  };
+  const jquery = () => item;
+  jquery.extend = (deep, target, source) => Object.assign(target, source);
+  const context = {
+    parent: { H5PEditor: {} },
+    navigator: { userAgent: '' },
+    H5P: { jQuery: jquery, trim: value => value.trim() }
+  };
+  context.window = context;
+  vm.createContext(context);
+  for (const file of ['h5peditor.js', 'h5peditor-text.js']) {
+    vm.runInContext(fs.readFileSync(path.join(__dirname, '../scripts', file), 'utf8'), context);
+  }
+  const editor = context.ns;
+  editor.t = (namespace, key) => key;
+  editor.checkErrors = (errors, input, value) => error ? false : value;
+  const field = new editor.Text(null, { name: 'title', ...options }, initial,
+    (field, value) => saved.push(value));
+  // Rendering markup is unrelated to the change and follow-field behavior.
+  field.createHtml = () => '';
+  field.appendTo({});
+  const parent = { children: [field], ready: callback => callback() };
+  return { field, saved, follow: callback => editor.followField(parent, 'title', callback) };
+}
+
+test('followField receives the initial text and subsequent stored values', () => {
+  const { field, saved, follow } = createText();
+  const values = [];
+  follow(value => values.push(value));
+  field.forceValue('Updated');
+  field.forceValue('<b>&');
+  assert.deepEqual(values, ['Initial', 'Updated', '&lt;b&gt;&']);
+  assert.deepEqual(saved, ['Updated', '&lt;b&gt;&']);
+});
+
+test('clearing optional text notifies followers with undefined', () => {
+  const { field, saved, follow } = createText('Initial', { optional: true });
+  const values = [];
+  follow(value => values.push(value));
+  field.forceValue('   ');
+  assert.deepEqual(values, ['Initial', undefined]);
+  assert.deepEqual(saved, [undefined]);
+});
+
+test('invalid text does not change the followed value or notify listeners', () => {
+  const { field, saved, follow } = createText();
+  const values = [];
+  follow(value => values.push(value));
+  field.forceValue('');
+  assert.deepEqual(values, ['Initial']);
+  assert.deepEqual(saved, []);
+});
+
+test('legacy change() and changeCallbacks subscribers still run once', () => {
+  const { field, follow } = createText();
+  const legacy = [];
+  const direct = [];
+  const followed = [];
+  assert.equal(field.change(value => legacy.push(value)), 0);
+  field.changeCallbacks.push(value => direct.push(value));
+  follow(value => followed.push(value));
+  field.forceValue('<b>');
+  assert.deepEqual(legacy, [undefined, '<b>']);
+  assert.deepEqual(direct, ['<b>']);
+  assert.deepEqual(followed, ['Initial', '&lt;b&gt;']);
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix with regression tests.

**What is the current behaviour?**

Text widgets expose `changeCallbacks`, but `followField` requires `changes` and reads `params`. Following a text field throws `noFollow`.

Fixes https://github.com/h5p/h5p-editor-php-library/issues/129

**What is the new behaviour?**

The text widget exposes the shared callback array and keeps `params` synchronized with the stored value, including removal of optional empty text. Existing `change()` and `changeCallbacks` subscribers retain their immediate-call behavior and raw changed-value argument.

Four Node regression tests load the actual editor helper and text widget scripts and cover `followField`, `findField`, `forceValue`, the change handler, escaped values, optional clearing, invalid input, and legacy subscribers. All four reproduced `noFollow` before the fix and pass afterward.

Validation: `npm test` (4 passing), JavaScript syntax checks, and `git diff --check`. No dependencies added. PHP-host/browser integration was not run; the harness stubs markup rendering and DOM error presentation.

AI assistance: developed and tested with OpenAI Codex.

## PR Checklist

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally
