### PR TITLE
fix: localize metadata author roles and additional information

### DIFF
--- a/language/ar.js
+++ b/language/ar.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'معلومات إضافية',
   missingTranslation: '[Missing translation :key]',
   loading: 'جاري التحميل الرجاءالانتظار...',
   selectLibrary: 'حدد المكتبة التي ترغب في استخدامها للمحتوى الخاص بك.',

--- a/language/bs.js
+++ b/language/bs.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Dodatne informacije',
   missingTranslation: '[Nedostaje prijevod :key]',
   loading: 'Učitava se, molimo sačekajte...',
   selectLibrary: 'Odaberite biblioteku koju želite koristiti za vaš sadržaj.',

--- a/language/cs.js
+++ b/language/cs.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Další informace',
   missingTranslation: '[Chybí překlad :key]',
   loading: 'Načítám, čekejte prosím ...',
   selectLibrary: 'Vyberte knihovnu, kterou chcete pro svůj obsah použít.',

--- a/language/de.js
+++ b/language/de.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Zusätzliche Informationen',
   missingTranslation: '[Fehlende Übersetzung :key]',
   loading: 'Lade, bitte warten...',
   selectLibrary: 'Wähle die Bibliothek, die für den Inhalt verwendet werden soll.',

--- a/language/el.js
+++ b/language/el.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Πρόσθετες πληροφορίες',
   missingTranslation: '[Λείπει μετάφραση :key]',
   loading: 'Φόρτωση, παρακαλούμε περιμένετε...',
   selectLibrary: 'Επιλέξτε τη βιβλιοθήκη την οποία θέλετε να χρησιμοποιήσετε για το περιεχόμενό σας.',

--- a/language/en.js
+++ b/language/en.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Additional information',
   missingTranslation: '[Missing translation :key]',
   loading: 'Loading, please wait...',
   selectLibrary: 'Select the library you wish to use for your content.',

--- a/language/es-cr.js
+++ b/language/es-cr.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Información adicional',
   missingTranslation: '[Falta la traducción :key]',
   loading: 'Cargando, por favor espera...',
   selectLibrary: 'Selecciona la librería que quiere usar con su contenido.',

--- a/language/es-mx.js
+++ b/language/es-mx.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Información adicional',
   missingTranslation: '[Falta la traducción :key]',
   loading: 'Cargando, por favor espera...',
   selectLibrary: 'Selecciona la librería que quieres usar con tu contenido.',

--- a/language/es.js
+++ b/language/es.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Información adicional',
   missingTranslation: '[Falta la traducción :key]',
   loading: 'Cargando, por favor espera...',
   selectLibrary: 'Selecciona la librería que quieres usar con tu contenido.',

--- a/language/et.js
+++ b/language/et.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Lisateave',
   missingTranslation: '[Puudub tõlge :key]',
   loading: 'Laadib, palun oota...',
   selectLibrary: 'Vali teek, mida soovid oma sisu jaoks kasutada.',

--- a/language/eu.js
+++ b/language/eu.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Informazio gehigarria',
   missingTranslation: '[Itzulpen galdua :key]',
   loading: 'Kargatzen, itxaron...',
   selectLibrary: 'Hautatu edukia garatzeko erabili nahi duzun liburutegia.',

--- a/language/fi.js
+++ b/language/fi.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Lisätietoja',
   missingTranslation: '[Missing translation :key]',
   loading: 'Lataa, odota...',
   selectLibrary: 'Valitse haluamasi kirjasto.',

--- a/language/fr.js
+++ b/language/fr.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Informations complémentaires',
   missingTranslation: '[Traduction manquante :key]',
   loading: 'Chargement en cours, merci de patienter...',
   selectLibrary: 'Sélectionnez une activité pour votre exercice.',

--- a/language/gl.js
+++ b/language/gl.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Información adicional',
   missingTranslation: '[Falta a tradución :key]',
   loading: 'Cargando, agarda, por favor...',
   selectLibrary: 'Selecciona a librería que queres usar para o teu contido.',

--- a/language/hr.js
+++ b/language/hr.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+    additionalInformation: 'Dodatne informacije',
     missingTranslation: '[Nedostaje prijevod: :key]',
     loading: 'Učitavanje, molimo pričekajte...',
     selectLibrary: 'Odaberite knjižnicu koju želite koristiti za vaš sadržaj.',

--- a/language/it.js
+++ b/language/it.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Informazioni aggiuntive',
   missingTranslation: '[Traduzione mancante :key]',
   loading: 'Caricamento, si prega di attendere...',
   selectLibrary: 'Seleziona la libreria che userai per i tuoi contenuti.',

--- a/language/ko.js
+++ b/language/ko.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: '추가 정보',
   missingTranslation: '[변환 누락 :key]',
   loading: '로드하는 중, 잠시 기다리십시오...',
   selectLibrary: '콘텐츠를 위해 사용할 라이브러리를 선택하십시오.',

--- a/language/nb.js
+++ b/language/nb.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Tilleggsinformasjon',
   missingTranslation: '[Mangler oversettelse :key]',
   loading: 'Laster, vennligst vent...',
   selectLibrary: 'Velg biblioteket du ønsker å bruke for innholdet ditt.',

--- a/language/nl.js
+++ b/language/nl.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Aanvullende informatie',
   missingTranslation: '[Vertaling ontbreekt :key]',
   loading: 'Laden, wachten alstublieft ...',
   selectLibrary: 'Selecteer de library die je wilt gebruiken voor je content.',

--- a/language/nn.js
+++ b/language/nn.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Tilleggsinformasjon',
   missingTranslation: '[Manglar oversettelse :key]',
   loading: 'Lastar, ver venleg og vent...',
   selectLibrary: 'Vel biblioteket du ønskjer å bruke for innhaldet ditt.',

--- a/language/pl.js
+++ b/language/pl.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Dodatkowe informacje',
   missingTranslation: '[Brakujące tłumaczenie :key]',
   loading: 'Wczytywanie proszę czekać...',
   selectLibrary: 'Wybierz typ zasobu, którego chcesz użyć.',

--- a/language/pt-br.js
+++ b/language/pt-br.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Informações adicionais',
   missingTranslation: '[Tradução ausente :key]',
   loading: 'Carregando, aguarde...',
   selectLibrary: 'Selecione a biblioteca que deseja usar em seu conteúdo.',

--- a/language/pt.js
+++ b/language/pt.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Informações adicionais',
   missingTranslation: '[Tradução em falta :key]',
   loading: 'A carregar. Por favor, aguarde...',
   selectLibrary: 'Selecione a biblioteca que pretende usar no seu conteúdo.',

--- a/language/ru.js
+++ b/language/ru.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Дополнительная информация',
   missingTranslation: '[Отсутствует перевод :key]',
   loading: 'Загрузка, пожалуйста подождите...',
   selectLibrary: 'Выберите библиотеку, которую вы хотите использовать для своего контента.',

--- a/language/sl.js
+++ b/language/sl.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Dodatne informacije',
   missingTranslation: '[Manjka prevod :key]',
   loading: 'Nalagam, počakajte prosim ...',
   selectLibrary: 'Izberite knjižnico, ki jo želite uporabiti za svojo vsebino.',

--- a/language/sv.js
+++ b/language/sv.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Ytterligare information',
   missingTranslation: '[Saknar översättning :key]',
   loading: 'Laddar, vänta ...',
   selectLibrary: 'Välj det bibliotek som du vill använda för ditt innehåll.',

--- a/language/tr.js
+++ b/language/tr.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: 'Ek bilgiler',
   missingTranslation: '[Eksik çeviri :key]',
   loading: ':type yükleniyor, bekleyin ...',
   selectLibrary: 'İçeriğiniz için kullanmak istediğiniz kitaplığı seçin.',

--- a/language/zh-cn.js
+++ b/language/zh-cn.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: '其他信息',
   missingTranslation: '[缺少翻译 :key]',
   loading: '加载中，请稍候...',
   selectLibrary: '请选择用于创建内容的库。',

--- a/language/zh-hans.js
+++ b/language/zh-hans.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: '其他信息',
   missingTranslation: '[缺少翻译 :key]',
   loading: '加载中，请稍候...',
   selectLibrary: '请选择用于创建内容的库。',

--- a/language/zh.js
+++ b/language/zh.js
@@ -1,4 +1,5 @@
 H5PEditor.language.core = {
+  additionalInformation: '其他信息',
   missingTranslation: '[缺少翻译 :key]',
   loading: '加载中，请稍候...',
   selectLibrary: '请选择用于创建内容的库。',

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A general library that is supposed to be used in most PHP implementations of H5P.",
   "scripts": {
+    "test": "node --test",
     "build": "webpack && rm styles/css/index.js",
     "watch": "webpack --watch"
   },

--- a/scripts/h5peditor-metadata-author-widget.js
+++ b/scripts/h5peditor-metadata-author-widget.js
@@ -126,12 +126,15 @@ H5PEditor.metadataAuthorWidget = function (semantics, params, $wrapper, parent) 
 
     const authorList = $('<ul></ul>');
     params.authors.forEach(function (author) {
+      const role = roleField.field.options.find(function (option) {
+        return option.value === author.role;
+      });
       // Name and role
       var listItem = $('<li>', {
         html: H5PEditor.htmlspecialchars(author.name),
         append: $('<span>', {
           'class': 'h5p-metadata-role',
-          html: author.role
+          text: role ? role.label : author.role
         })
       });
 

--- a/scripts/h5peditor-metadata.js
+++ b/scripts/h5peditor-metadata.js
@@ -320,7 +320,7 @@ H5PEditor.MetadataForm = (function (EventDispatcher, $, metadataSemantics) {
     // Append the Additional information group
     var additionals = new H5PEditor.widgets.group(self, {
       name: 'additionals',
-      label: 'Additional information', // TODO: l10n ?
+      label: H5PEditor.t('core', 'additionalInformation'),
       fields: [
         findField('authorComments')
       ]

--- a/test/metadata-author-widget.test.js
+++ b/test/metadata-author-widget.test.js
@@ -1,0 +1,53 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, '../scripts/h5peditor-metadata-author-widget.js'), 'utf8');
+
+function renderRoles(authors, options) {
+  const roles = [];
+  const element = {
+    append() { return this; },
+    appendTo() { return this; },
+    children() { return this; },
+    click() { return this; },
+    end() { return this; },
+    find() { return this; },
+    empty() { return this; }
+  };
+  const editor = {
+    $(tag, attributes) {
+      if (tag === '<span>') {
+        roles.push(attributes);
+      }
+      return element;
+    },
+    processSemanticsChunk() {},
+    findField(name) {
+      return name === 'role' ? { field: { options } } : {};
+    },
+    htmlspecialchars(value) { return value; },
+    t(core, key) { return key; }
+  };
+  vm.runInNewContext(source, { H5PEditor: editor });
+  editor.metadataAuthorWidget([], { authors }, element, {});
+  return roles;
+}
+
+test('renders translated role labels without changing stored role values', () => {
+  const authors = [{ name: 'Alice', role: 'Author' }, { name: 'Bob', role: 'Editor' }];
+  const roles = renderRoles(authors, [
+    { value: 'Author', label: 'Auteur' },
+    { value: 'Editor', label: 'Éditeur' }
+  ]);
+  assert.deepEqual(roles.map(role => role.text), ['Auteur', 'Éditeur']);
+  assert.deepEqual(authors.map(author => author.role), ['Author', 'Editor']);
+});
+
+test('preserves unknown roles as plain text', () => {
+  const roles = renderRoles([{ name: 'Alice', role: '<custom-role>' }], []);
+  assert.equal(roles[0].text, '<custom-role>');
+  assert.equal(roles[0].html, undefined);
+});

--- a/test/metadata-translations.test.js
+++ b/test/metadata-translations.test.js
@@ -1,0 +1,21 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const languageDirectory = path.join(__dirname, '../language');
+const editorSource = fs.readFileSync(path.join(__dirname, '../scripts/h5peditor-editor.js'), 'utf8');
+
+for (const file of fs.readdirSync(languageDirectory).filter(file => file.endsWith('.js'))) {
+  test(`additional information label is available in ${file}`, () => {
+    const context = { H5PEditor: { language: {} } };
+    context.window = context;
+    vm.createContext(context);
+    vm.runInContext(editorSource, context);
+    vm.runInContext(fs.readFileSync(path.join(languageDirectory, file), 'utf8'), context);
+    const translated = context.H5PEditor.t('core', 'additionalInformation');
+    assert.ok(translated.length > 0);
+    assert.ok(!translated.startsWith('Missing translation'), translated);
+  });
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix with localization updates and regression tests.

**What is the current behaviour?**

Saved metadata authors display raw role values even when the selector has translated labels, and the additional-information group uses a hardcoded English heading.

Fixes https://github.com/h5p/h5p-editor-php-library/issues/69

**What is the new behaviour?**

Author roles resolve against the selector's existing translated semantics options while preserving stored values and using plain-text fallback for unknown roles. The additional-information heading uses a new core translation key present in all 30 locale dictionaries.

Validation: all 32 dependency-free Node tests pass, including translation availability through the actual translator for every locale. The role tests and missing-key assertions fail on the original source. Script syntax and diff checks pass. The actual author widget was also checked in jsdom with H5P core's bundled jQuery 3.5.1: translated labels display, unknown roles remain literal text, and stored metadata stays unchanged. No PHP integration or live browser test was run.

AI assistance: developed and validated with OpenAI Codex; maintainer and native-language review of the locale wording is welcome.

## PR Checklist

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally
